### PR TITLE
filterUpdated combined into filteredDisplays

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,13 +7,12 @@ const [filter, setFilter] = createSignal("");
 const [filterHori, setFilterHori] = createSignal(NaN);
 const [filterVerti, setFilterVerti] = createSignal(NaN);
 
-// createEffect(() => console.log(filter()));
-// createEffect(() => console.log(filterHori()));
-// createEffect(() => console.log(filterVerti()));
+createEffect(() => console.log(filter()));
+createEffect(() => console.log(filterHori()));
+createEffect(() => console.log(filterVerti()));
 
 const filteredDisplays = createMemo(() => {
   let displays = mockDisplayData ?? [];
-  console.log("before first if statement inside filteredDisplays");
   if (filter() !== "") {
     displays = displays.filter(
       (display) =>
@@ -22,19 +21,16 @@ const filteredDisplays = createMemo(() => {
         display.vertical_resolution.toString().includes(filter())
     );
   }
-  console.log("before second if statement inside filteredDisplays");
   if (typeof filterHori() === "number" && !isNaN(filterHori())) {
     displays = displays.filter(
       (display) => display.horizontal_resolution === filterHori()
     );
   }
-  console.log("before third if statement inside filteredDisplays");
   if (typeof filterVerti() === "number" && !isNaN(filterVerti())) {
     displays = displays.filter(
       (display) => display.vertical_resolution === filterVerti()
     );
   }
-  console.log("before final return of displays");
   return displays;
 }, [filter, filterHori, filterVerti]);
 


### PR DESCRIPTION
filter based on already filtered list. One way to achieve this is to modify the createMemo function to accept a dependency list as the second parameter.

By including [filter, filterHori, filterVerti] as the second parameter to createMemo, the memo will recompute whenever any of these signals change.

This modified filteredDisplays memo will first filter by the filter() signal, and then filter by filterHori() and filterVerti() signals on the already filtered list. This ensures that the filtering is cumulative and takes into account the previous filters applied.